### PR TITLE
Add emacs themes

### DIFF
--- a/witchhazel-hypercolor-theme.el
+++ b/witchhazel-hypercolor-theme.el
@@ -1,0 +1,52 @@
+(deftheme witchhazel-hypercolor "A dark, feminine color theme.")
+
+(custom-theme-set-faces
+ 'witchhazel-hypercolor
+ '(default ((t (:foreground "#f8f8f2" :background "#282634"))))
+ '(fringe ((t (:inherit default))))
+ '(font-lock-comment-face ((t (:foreground "#bfbfbf"))))
+ '(font-lock-comment-delimiter-face ((t (:inherit font-lock-comment-face))))
+ '(font-lock-string-face ((t (:foreground "#81eeff"))))
+ '(font-lock-constant-face ((t (:foreground "#c5a3ff" :weight bold))))
+ '(font-lock-keyword-face ((t (:foreground "#81ffbe" :slant italic))))
+ '(font-lock-type-face ((t (:foreground "#a3f3ff"))))
+ '(font-lock-function-name-face ((t (:foreground "#dcc8ff"))))
+ '(font-lock-variable-name-face ((t (:inherit default))))
+ '(font-lock-builtin-face ((t (:foreground "#dcc8ff"))))
+ '(button ((t (:foreground "#81eeff" :underline t))))
+ '(region ((t (:background "#8077a8"))))
+ '(highlight ((t (:foreground "#131218" :background "#64cb96"))))
+ '(mode-line ((t (:foreground "#f8f8f0" :background "#8864cb"))))
+ '(mode-line-inactive ((t (:foreground "#f8f8f0" :background "#634e89"))))
+ '(match ((t (:background "#8864cb"))))
+ '(isearch ((t (:inherit match))))
+ '(minibuffer-prompt ((t (:foreground "#dcc8ff"))))
+ '(hl-line ((t (:background "#131218"))))
+ '(whitespace-space ((t (:foreground "#894e63"))))
+ '(whitespace-trailing ((t (:background "#894e63"))))
+ ;; `company-mode'
+ '(company-tooltip ((t (:background "#433e56"))))
+ '(company-tooltip-selection ((t (:background "#634e89"))))
+ '(company-tooltip-mouse ((t (:foreground "#131218" :background "#64cb96"))))
+ '(company-scrollbar-fg ((t (:background "#ae81ff"))))
+ '(company-scrollbar-bg ((t (:inherit company-tooltip))))
+ ;; `highlight-numbers-mode'
+ '(highlight-numbers-number ((t (:foreground "#fff9a3"))))
+ ;; `ivy-mode'
+ '(ivy-current-match ((t (:background "#634e89"))))
+ '(ivy-highlight-face ((t (:underline t))))
+ ;; `markdown-mode'
+ '(markdown-header-face ((t (:foreground "#fff781" :weight bold))))
+ '(markdown-header-delimiter-face ((t (:inherit markdown-header-face))))
+ '(markdown-link-face ((t (:foreground "#81ffbe" :weight bold))))
+ '(markdown-link-title-face ((t (:foreground "#81eeff"))))
+ '(markdown-url-face ((t (:foreground "#c8f8ff" :underline t :slant italic))))
+ ;; `rust-mode'
+ '(rust-string-interpolation ((t (:foreground "#ffa3c3" :slant italic))))
+ '(rust-question-mark ((t (:foreground "#81ffbe"))))
+ ;; `smartparens'
+ '(sp-pair-overlay-face ((t (:background "#131218"))))
+ ;; `swiper'
+ '(swiper-line-face ((t (:background "#131218")))))
+
+(provide-theme 'witchhazel-hypercolor)

--- a/witchhazel-theme.el
+++ b/witchhazel-theme.el
@@ -1,0 +1,61 @@
+;;; witchhazel-theme.el --- A dark, feminine color theme.
+
+;; Version: 1.0
+
+(deftheme witchhazel "A dark, feminine color theme.")
+
+(custom-theme-set-faces
+ 'witchhazel
+ '(default ((t (:foreground "#f8f8f2" :background "#433e56"))))
+ '(fringe ((t (:inherit default))))
+ '(font-lock-comment-face ((t (:foreground "#b0bec5"))))
+ '(font-lock-comment-delimiter-face ((t (:inherit font-lock-comment-face))))
+ '(font-lock-string-face ((t (:foreground "#1bc5e0"))))
+ '(font-lock-constant-face ((t (:foreground "#c5a3ff"))))
+ '(font-lock-keyword-face ((t (:foreground "#c2ffdf" :slant italic))))
+ '(font-lock-type-face ((t (:foreground "#c2ffdf"))))
+ '(font-lock-function-name-face ((t (:foreground "#ceb1ff"))))
+ '(font-lock-variable-name-face ((t (:inherit default))))
+ '(font-lock-builtin-face ((t (:foreground "#ceb1ff"))))
+ '(button ((t (:foreground "#2cb5cc" :underline t))))
+ '(region ((t (:background "#8077a8"))))
+ '(highlight ((t (:foreground "#f8f8f2" :background "#555166"))))
+ '(mode-line ((t (:foreground "#f8f8f2" :background "#716799"))))
+ '(mode-line-inactive ((t (:foreground "#f8f8f2" :background "#544b7a"))))
+ '(match ((t (:background "#a37c8a"))))
+ '(isearch ((t (:inherit match))))
+ '(minibuffer-prompt ((t (:foreground "#ceb1ff"))))
+ '(hl-line ((t (:background "#716799"))))
+ '(whitespace-space ((t (:foreground "#a8757b"))))
+ '(whitespace-trailing ((t (:foreground "#a8757b"))))
+ ;; `company-mode'
+ '(company-tooltip ((t (:background "#353144"))))
+ '(company-tooltip-selection ((t (:background "#716799"))))
+ '(company-tooltip-mouse ((t (:inherit highlight))))
+ '(company-scrollbar-fg ((t (:background "#646464"))))
+ '(company-scrollbar-bg ((t (:inherit company-tooltip))))
+ ;; `highlight-numbers-mode'
+ '(highlight-numbers-number ((t (:foreground "#c5a3ff"))))
+ ;; `ivy-mode'
+ '(ivy-current-match ((t (:background "#716799"))))
+ '(ivy-highlight-face ((t (:underline t))))
+ ;; `markdown-mode'
+ '(markdown-header-face ((t (:foreground "#fff352" :weight bold))))
+ '(markdown-header-delimiter-face ((t (:inherit markdown-header-face))))
+ '(markdown-link-face ((t (:foreground "#1bc5e0" :weight bold))))
+ '(markdown-link-title-face ((t (:foreground "#1bc5e0"))))
+ '(markdown-url-face ((t (:foreground "#c2ffdf" :underline t :slant italic))))
+ ;; `rust-mode'
+ '(rust-string-interpolation ((t (:foreground "#c5a3ff"))))
+ '(rust-question-mark ((t (:foreground "#c2ffdf"))))
+ ;; `swiper'
+ '(swiper-line-face ((t (:background "#555166")))))
+
+;;;###autoload
+(and load-file-name (boundp 'custom-theme-load-path)
+  (add-to-list 'custom-theme-load-path (file-name-directory load-file-name)))
+
+(provide-theme 'witchhazel)
+
+(provide 'witchhazel-theme)
+;;; witchhazel-theme.el ends here


### PR DESCRIPTION
The screenshots also use the `highlight-numbers` package, which is required for changing the color of numbers, but isn't required to use the theme. The theme also supports a few other 3rd-party packages, like `company-mode`. Feedback would be great!

Here's a screenshot of the classic theme:
![image](https://user-images.githubusercontent.com/19535335/126542837-536253e0-b634-45fd-827d-14e3224a6241.png)

And here's a screenshot of the hypercolor theme:
![image](https://user-images.githubusercontent.com/19535335/126542871-73e87d6d-af9d-4403-9a5e-df3b06e38eae.png)
