### PR TITLE
Add Witch Hazel Xcode theme

### DIFF
--- a/witch-hazel.xccolortheme
+++ b/witch-hazel.xccolortheme
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTSourceTextBackground</key>
+	<string>0.20472367107868195 0.18062958121299744 0.2738516926765442 1.0</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.37413299083709717 0.3174234628677368 0.5449860692024231 1.0</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>0.9655500650405884 0.9669021368026733 0.9225867390632629 1.0</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.6279568672180176 0.3644733428955078 0.404657781124115 1.0</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.4327508509159088 0.37918543815612793 0.6098873019218445 1.0</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.9655274748802185 0.9665472507476807 0.9332761764526367 1.0</string>
+		<key>xcode.syntax.character</key>
+		<string>0.7486729621887207 0.5395463109016418 1.0 1.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.2306276261806488 0.4640737771987915 0.5982968211174011 1.0</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.6426465511322021 1.0 0.8339443802833557 1.0</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.6426465511322021 1.0 0.8339443802833557 1.0</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>0.7872618436813354 0.6064720749855042 1.0 1.0</string>
+		<key>xcode.syntax.declaration.type</key>
+		<string>0.6426465511322021 1.0 0.8339443802833557 1.0</string>
+		<key>xcode.syntax.identifier.class</key>
+		<string>0.7486729621887207 0.5395463109016418 1.0 1.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>0.7872618436813354 0.6064720749855042 1.0 1.0</string>
+		<key>xcode.syntax.identifier.constant</key>
+		<string>0.7486729621887207 0.5395463109016418 1.0 1.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>0.7486729621887207 0.5395463109016418 1.0 1.0</string>
+		<key>xcode.syntax.identifier.function</key>
+		<string>0.7872618436813354 0.6064720749855042 1.0 1.0</string>
+		<key>xcode.syntax.identifier.function.system</key>
+		<string>0.7872618436813354 0.6064720749855042 1.0 1.0</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>0.7486729621887207 0.5395463109016418 1.0 1.0</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>0.7486729621887207 0.5395463109016418 1.0 1.0</string>
+		<key>xcode.syntax.identifier.type</key>
+		<string>0.7486729621887207 0.5395463109016418 1.0 1.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>0.7872618436813354 0.6064720749855042 1.0 1.0</string>
+		<key>xcode.syntax.identifier.variable</key>
+		<string>0.9655274748802185 0.9665472507476807 0.9332761764526367 1.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>0.6426465511322021 1.0 0.8339443802833557 1.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.6426465511322021 1.0 0.8339443802833557 1.0</string>
+		<key>xcode.syntax.mark</key>
+		<string>0.6426465511322021 1.0 0.8339443802833557 1.0</string>
+		<key>xcode.syntax.number</key>
+		<string>0.7486729621887207 0.5395463109016418 1.0 1.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.9655274748802185 0.9665472507476807 0.9332761764526367 1.0</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>0.7486729621887207 0.5395463109016418 1.0 1.0</string>
+		<key>xcode.syntax.string</key>
+		<string>0.0 0.7449789643287659 0.8665486574172974 1.0</string>
+		<key>xcode.syntax.url</key>
+		<string>0.6426465511322021 1.0 0.8339443802833557 1.0</string>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
Work in progress. I'm copying the colours to from the tm theme to the json file and then using https://github.com/inket/Transmog to convert it to something Xcode can understand. It's rough right now but in the right direction.
<img width="1512" alt="Screen Shot 2021-08-15 at 9 41 53 PM" src="https://user-images.githubusercontent.com/6799989/129500771-c370c679-a045-48c8-847e-f54849457c36.png">
