### PR TITLE
Add colors for resources that have been changed

### DIFF
--- a/Witch Hazel-color-theme.json
+++ b/Witch Hazel-color-theme.json
@@ -71,7 +71,15 @@
 		"titleBar.activeBackground": "#464258",
 		"titleBar.activeForeground": "#F8F8F2",
 		"titleBar.inactiveBackground": "#3a3553",
-		"titleBar.inactiveForeground": "#b9b9b9"
+		"titleBar.inactiveForeground": "#b9b9b9",
+        "gitDecoration.addedResourceForeground": "#C2FFDF",
+        "gitDecoration.modifiedResourceForeground": "#FFF781",
+        "gitDecoration.deletedResourceForeground": "#C5A3FF",
+        "gitDecoration.renamedResourceForeground": "#C2FFDF",
+		"gitDecoration.stageModifiedResourceForeground": "#64CB96",
+        "gitDecoration.stageDeletedResourceForeground": "#8077A8",
+        "gitDecoration.untrackedResourceForeground": "#b9b9b9",
+        "gitDecoration.ignoredResourceForeground": "#B0BEC5"
 	},
 	"name": "Witch Hazel"
 }


### PR DESCRIPTION
**What does this PR do?**
Add colors for added, renamed, untracked and ignored resources.
Add different colors for unstaged and staged modified and deleted resources.

**Why?**
I've been using Witch Hazel as my current theme, and I've realised the default colors for these were making version control related operations (seeing what change I've made, and if I've staged it or not) was annoying to determine.

I hope these changes will help others who are using this theme often in their everyday work.

(I haven't used Hypercolor, so I wasn't sure what colors to pick there.)

**Screenshots**

Added resource looks like this in the sidebar:
<img width="420" alt="new" src="https://user-images.githubusercontent.com/1133238/136618502-72cd1443-0e6b-4f17-8dac-f1a44eb28394.png">

Ignored and unstaged modified:
<img width="426" alt="ignored and modified" src="https://user-images.githubusercontent.com/1133238/136618818-71cad045-e3cf-4a23-af66-b916be98a8de.png">

Untracked, staged modified and renamed resources:
<img width="420" alt="untracked, modified staged and renamed" src="https://user-images.githubusercontent.com/1133238/136618560-61659665-50ff-446c-901a-675f53098994.png">

Renamed and added resources use the same color, as there wasn't another light green shade in the theme colors.

Ignored and untracked are almost the same color (light gray), which I think will be almost impossible to distinguish if they are on top of each other. I chose different grays because there were so many different shades of grays available in the theme colors 🙈

All the same colors are repeated in the editor group's tabs:

<img width="1193" alt="editor group tabs" src="https://user-images.githubusercontent.com/1133238/136619880-fd48741a-1a94-499e-89ee-d6c94e5d128e.png">

Unstaged deleted and staged deleted colors aren't visible in the sidebar or the editor group's tabs, only in the version control activity bar:
<img width="422" alt="all staged and unstaged" src="https://user-images.githubusercontent.com/1133238/136619980-d1d1818e-5157-463d-8756-06b25308c394.png">

P.S. I'm participating in Hacktoberfest and if you feel like this PR is following the rules of the event, I'd really appreciate if you could label this PR as "hacktoberfest-accepted" 🙇🏼‍♀️ Thank you for reviewing and thank you for maintaining this theme! 💖🧙🏻‍♀️
