### PR TITLE
Add colors for errors and warnings

### DIFF
--- a/Witch Hazel-color-theme.json
+++ b/Witch Hazel-color-theme.json
@@ -79,7 +79,17 @@
 		"gitDecoration.stageModifiedResourceForeground": "#64CB96",
         "gitDecoration.stageDeletedResourceForeground": "#8077A8",
         "gitDecoration.untrackedResourceForeground": "#b9b9b9",
-        "gitDecoration.ignoredResourceForeground": "#B0BEC5"
+        "gitDecoration.ignoredResourceForeground": "#B0BEC5",
+		"list.errorForeground": "#FF81AD",
+        "list.warningForeground": "#FF857F",
+        "minimap.errorHighlight": "#FF81AD",
+        "minimap.warningHighlight": "#FF857F",
+        "editorOverviewRuler.errorForeground": "#FF81AD",
+        "editorOverviewRuler.warningForeground": "#FF857F",
+        "editorError.foreground": "#F92672",
+        "editorWarning.foreground": "#FF857F",
+        "problemsErrorIcon.foreground": "#FF81AD",
+        "problemsWarningIcon.foreground": "#FF857F",
 	},
 	"name": "Witch Hazel"
 }


### PR DESCRIPTION
**What does this PR do?**
Add better colors to code squiggles, minimap, editor overview ruler, sidebar list and problems console tab icons.

**Why?**
These changes make it less annoying to look at errors and warnings when they happen.
(Actuallly, now I think someone will want to have some errors somewhere because that pink is too cute 🙈)

**Screenshots**

Error and warning squiggles in code:
<img width="468" alt="squiggles" src="https://user-images.githubusercontent.com/1133238/136711586-3427f468-a0e9-4a28-b4db-eb3341bbce20.png">

I considered using the same pink (#FF81AD) in the squiggles as everywhere else, but if an error and a warning where on the same line or adjacent lines, the colors would be almost indistinguishable:

<img width="344" alt="indistinguishable" src="https://user-images.githubusercontent.com/1133238/136712376-e3598ece-7143-4b57-bcc4-b9e636bc3503.png">

So I looked around for a more bright red for that one (#F92672) and found one in `witchhazel.py`.

Sidebar:
<img width="327" alt="sidebar" src="https://user-images.githubusercontent.com/1133238/136711567-e9d2bca1-cae9-47b5-a6a2-e78128bd3601.png">

File names in editor group tabs, minimap and editor overview ruler:
<img width="768" alt="minimap and editor gutter" src="https://user-images.githubusercontent.com/1133238/136711686-ceb6664d-1777-4553-abd0-76ac8a77eda3.png">
Problems console tab's icons:
<img width="597" alt="icons" src="https://user-images.githubusercontent.com/1133238/136711593-2ad12b14-bc67-49b9-8983-27e19f351471.png">

P.S. Same as with the previous PR, if you feel like this PR is following the rules of Hacktoberfetst, I'd really appreciate if you add the "hacktoberfest-accepted" label. Thank you 🙇🏼‍♀️
