### PR TITLE
Git decorations for hypercolor theme

### DIFF
--- a/Witch Hazel-hypercolor-theme.json
+++ b/Witch Hazel-hypercolor-theme.json
@@ -129,6 +129,14 @@
 		"debugView.exceptionLabelForeground": "#FF81AD",
 		"debugExceptionWidget.background": "#CB6488",
 		"debugExceptionWidget.border": "#CB6488",
+		"gitDecoration.addedResourceForeground": "#A3F3FF",
+		"gitDecoration.modifiedResourceForeground": "#FFF781",
+		"gitDecoration.deletedResourceForeground": "#FFA3C3",
+		"gitDecoration.renamedResourceForeground": "#81EEFF",
+		"gitDecoration.stageModifiedResourceForeground":"#81FFBE",
+		"gitDecoration.stageDeletedResourceForeground":"#FF81AD",
+		"gitDecoration.untrackedResourceForeground":"#C8F8FF",
+		"gitDecoration.ignoredResourceForeground":"#DCC8FFAA"
 	},
 	"name": "Witch Hazel"
 }


### PR DESCRIPTION
Fixes #22

I'd be happy to get some feedback on this! Some of the areas backgrounds change from dark to very light, so finding a color that works with both was a bit of a challenge (for example the light-green hover), so I'm open to suggestions on how to improve that. 😊

If these changes are useful and become accepted, it would be awesome if this pr could get `hacktoberfest-accepted`-labeled!

## Editor overview
<img width="1792" alt="Screenshot 2021-10-14 at 17 31 07" src="https://user-images.githubusercontent.com/26743924/137338708-88899a88-8928-4141-ab5d-fb58d1c10816.png">


## Top bar
<img width="1217" alt="Screenshot 2021-10-14 at 17 31 42" src="https://user-images.githubusercontent.com/26743924/137338734-233fb073-af00-490f-afa6-e2d4475aaab1.png">

## Sidebar
<img width="375" alt="Screenshot 2021-10-14 at 17 31 17" src="https://user-images.githubusercontent.com/26743924/137338765-4b261081-3adc-42c1-9920-33597cfa2814.png">

Pretty bad contrast when hover:
<img width="371" alt="Screenshot 2021-10-14 at 17 32 06" src="https://user-images.githubusercontent.com/26743924/137338802-7b152e2b-7d79-4695-ab29-160a6064b15a.png">

## Version control area 
<img width="373" alt="Screenshot 2021-10-14 at 17 31 32" src="https://user-images.githubusercontent.com/26743924/137338978-dce172c7-0b17-48b6-8a26-aacc48f38789.png">

