### PR TITLE
More distinct colouring for "active" file tab in VSCode

### DIFF
--- a/Witch Hazel-color-theme.json
+++ b/Witch Hazel-color-theme.json
@@ -27,6 +27,7 @@
 		"sideBarSectionHeader.background": "#48425c",
 		"sideBarSectionHeader.foreground": "#F8F8F2",
 		"activityBar.background": "#353144",
+		"tab.activeBackground": "#716799",
 		"tab.inactiveBackground": "#464258",
 		"tab.inactiveForeground": "#F8F8F2",
 		"tab.border": "#464258",


### PR DESCRIPTION
Implement the change for #24

I chose the colour to match that used for `editor.lineHighlightBackground`.