### PR TITLE
Add colors to overview ruler, editor gutter, minimap and minimap gutter

### DIFF
--- a/Witch Hazel-color-theme.json
+++ b/Witch Hazel-color-theme.json
@@ -91,6 +91,18 @@
         "editorWarning.foreground": "#FF857F",
         "problemsErrorIcon.foreground": "#FF81AD",
         "problemsWarningIcon.foreground": "#FF857F",
+		"editorOverviewRuler.modifiedForeground": "#FFF781",
+        "editorOverviewRuler.addedForeground": "#C2FFDF",
+        "editorOverviewRuler.deletedForeground": "#8077A8",
+		"editorOverviewRuler.findMatchForeground": "#7f5c68",
+        "editorGutter.modifiedBackground": "#FFF781",
+        "editorGutter.addedBackground": "#C2FFDF",
+        "editorGutter.deletedBackground": "#8077A8",
+        "minimapGutter.modifiedBackground": "#FFF781",
+        "minimapGutter.addedBackground": "#C2FFDF",
+        "minimapGutter.deletedBackground": "#8077A8",
+        "minimap.findMatchHighlight": "#7f5c68",
+        "minimap.selectionHighlight": "#C5A3FF",
 	},
 	"name": "Witch Hazel"
 }


### PR DESCRIPTION
**What does this PR do?**
Add colors for modified, added or deleted resources in editor overview ruler, editor gutter and minimap gutter.
Also add find match and selection highlight colors in minimap.
Also add find match color in editor overview ruler.

**Why?**
Now that there are colors that indicate modified, added and deleted resources in file names and list (#19), it would be nice to have the same colors in other parts of the UI, like:

- editor gutter (just to the right of code line numbers)
- editor overview ruler (the scroll bar to the most right)
- minimap (small overview of the whole file) and its gutter

**Screenshots**
Overall (with find match and error):
<img width="859" alt="overall screenshot" src="https://user-images.githubusercontent.com/1133238/137859297-c4cb0d94-c5d8-4b09-9f1d-9608fb1349ec.png">

Editor gutter (with added and deleted lines):
<img width="332" alt="deleted and added in editor gutter" src="https://user-images.githubusercontent.com/1133238/137859339-3e2613be-9682-403c-8eb0-94aa4b8758ae.png">

Minimap (with selected row and modified highlight in gutter):
<img width="106" alt="Minimap and gutter" src="https://user-images.githubusercontent.com/1133238/137859744-057355b3-2e1e-4d0b-9035-dd2cdce92bfc.png">

P.S. And would be nice to get the "hacktoberfest-accepted" to this one too. Thanks! 🙇 