### PR TITLE
Add merge and diff related colors to Witch Hazel VS Code theme

### DIFF
--- a/Witch Hazel-color-theme.json
+++ b/Witch Hazel-color-theme.json
@@ -108,7 +108,17 @@
         "settings.checkboxForeground": "#F8F8F2",
         "settings.checkboxBorder": "#F8F8F2",
         "settings.headerForeground": "#8077A8",
-		"settings.focusedRowBorder": "#C5A3FF"
+		"settings.focusedRowBorder": "#C5A3FF",
+		"diffEditor.removedTextBackground": "#7f5c68",
+		"diffEditor.insertedTextBackground" : "#6A8D7A",
+		"gitlens.trailingLineForegroundColor": "#F8F8F2",
+		"merge.currentHeaderBackground":  "#a59900",
+		"merge.currentContentBackground": "#7d7100",
+		"merge.incomingHeaderBackground": "#008ea7",
+		"merge.incomingContentBackground": "#005c75",
+		"merge.border": "#F8F8F2",
+		"editorOverviewRuler.currentContentForeground": "#7d7100",
+		"editorOverviewRuler.incomingContentForeground": "#005c75",
 	},
 	"name": "Witch Hazel"
 }


### PR DESCRIPTION
# What is this PR about?


Add better colors for:
- diff editor
- merge conflicts view
- [gitlens](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens) trailing blame line

# Which editor(s) does this change concern?

- [x] VS Code
- [ ] Sublime
- [ ] JetBrains
- [ ] Atom
- [ ] Pygments
- [ ] Other: ________

# The changes are for following theme variant(s):

- [ ] Hypercolor
- [x] Classic

# Screenshots
Diff editor:
<img width="1064" alt="diff view colors" src="https://user-images.githubusercontent.com/1133238/142676663-0f2d5490-71c3-4426-a528-e525b492fdc2.png">

Merge conflict:
<img width="802" alt="Screenshot 2021-11-19 at 19 50 38" src="https://user-images.githubusercontent.com/1133238/142676681-beebec1f-d4f2-4499-b993-cb0f3b497108.png">

Gitlens trailing blame color:
<img width="1008" alt="gitlens trailing line" src="https://user-images.githubusercontent.com/1133238/142677315-d62b61f7-34ef-42e2-88ab-9a40b05e535d.png">
