### PR TITLE
add documentation around vim

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -18,7 +18,7 @@
       <img src="logo.png" alt="Witch Hazel logo" title="Witch Hazel logo">
     </p>
     <h1>Witch Hazel</h1>
-    <h2>A dark &amp; feminine color scheme for Sublime, VS Code, JetBrains, and Pygments.</h2>
+    <h2>A dark &amp; feminine color scheme for Sublime, VS Code, JetBrains, Pygments, Atom, and Vim.</h2>
     <p class="buttons">
       <span data-button-group>
         <button data-target="img-hypercolor" class="active" type="button">Hypercolor</button>
@@ -42,6 +42,7 @@
       <button data-target="jetbrains" type="button">JetBrains</button>
       <button data-target="atom" type="button">Atom</button>
       <button data-target="pygments" type="button">Pygments</button>
+      <button data-target="vim" type="button">Vim</button>
       <button data-target="others" type="button">Others</button>
     </div>
 
@@ -99,6 +100,32 @@
         <li>Locate the Atom packages directory (listed at the top of <code>Settings -> Install</code>).</li>
         <li>Unzip the theme folder into the Atom packages directory.</li>
         <li>Pick <code>Witch Hazel</code> using <code>Settings -> Themes -> Syntax Theme</code>.</li>
+      </ol>
+    </section>
+
+    <section id="vim">
+      <h3><a href="https://www.vim.org/">Vim</a> and <a href="https://neovim.io/">Neovim</a> installation</h3>
+      <em>Note for either vim or neovim the <code>termguicolors</code> global option should be true</em></br></br>
+      With <a href="https://github.com/junegunn/vim-plug">vim-plug</a>:
+      <ol>
+        <li>Add the vimscript command <code>Plug 'theacodes/witchhazel'</code> alongside your other plugins between <code>plug#begin()</code> and <code>plug#end()</code></li>
+        <li>Source the modified file and run the vimscript command <code>PlugInstall</code></li>
+        <li>Add the vimscript command <code>colorscheme witchhazel</code> to your <code>.vimrc</code> or <code>init.vim</code></li>
+        <li>Restart <code>vim</code> or run the vimscript command <code>colorscheme witchhazel</code></li>
+      </ol>
+      With <a href="https://github.com/wbthomason/packer.nvim">packer.nvim</a> (Neovim only):
+      <ol>
+        <li>Add the table <code>use { "theacodes/witchhazel" }</code> to the <code>packer.startup</code> call</li>
+        <li>Source the modified file and run the vimscript command <code>PackerSync</code></li>
+        <li>Add <code>vim.cmd "colorscheme witchhazel"</code> to your <code>init.lua</code></li>
+        <li>Restart <code>nvim</code> or run the vimscript command <code>colorscheme witchhazel</code></li>
+      </ol>
+      Manual installation:
+      <ol>
+        <li>Download the theme: <a href="https://raw.githubusercontent.com/theacodes/witchhazel/master/colors/witchhazel.vim">Classic</a>, <a href="https://raw.githubusercontent.com/theacodes/witchhazel/master/colors/witchhazel-hypercolor.vim">Hypercolor</a>.</li>
+        <li>Copy the file to the colors directory (default <code>$HOME/.vim/colors/</code> for Vim, <code>$HOME/.config/nvim/colors/</code> for Neovim)</li>
+        <li>Add the vimscript command <code>colorscheme witchhazel</code> to your <code>.vimrc</code> or <code>init.vim</code></li>
+        <li>Restart <code>vim</code> or run the vimscript command <code>colorscheme witchhazel</code></li>
       </ol>
     </section>
 


### PR DESCRIPTION
# What is this PR about?
Filling in missing documentation

[ ] closes issue number #

(Describe what are the changes and why you have made them.)
I originally came to https://witchhazel.thea.codes/ looking for a neovim plugin. I almost left to look for new colorschemes when I though I saw it wasn't supported. But then I checked the source and saw it did in fact work, and was already compatible!
Just trying to help the next vim user get set up a bit quicker.

# Which editor(s) does this change concern?

- [ ] VS Code
- [ ] Sublime
- [ ] JetBrains
- [ ] Atom
- [ ] Pygments
- [X] Other: ___vim_____

# The changes are for following theme variant(s):

- [ ] Hypercolor
- [ ] Classic

(If your change is only for one of these, please consider [submitting an issue](https://github.com/theacodes/witchhazel/issues/new) to document it to other contributors that these features are missing from the other variant. Having them listed in an issue makes it easier for people to contribute! 🎉)

# Screenshots
![Screen Shot 2022-06-16 at 14 07 24](https://user-images.githubusercontent.com/28751151/174163779-0410e412-dc1a-4f2f-84a7-2091a17dad88.png)

![Screen Shot 2022-06-16 at 14 07 35](https://user-images.githubusercontent.com/28751151/174163790-4dae09f6-fcf8-4a93-aac4-3ebdec6b7747.png)


(Providing screenshots makes reviewing this PR quicker and easier.)