### PR TITLE
Add Lite XL themes

### DIFF
--- a/lite-xl/README.md
+++ b/lite-xl/README.md
@@ -1,0 +1,15 @@
+Witch Hazel and Witch Hazel Hypercolor themes for the
+[Lite XL](https://lite-xl.com/) editor.
+
+To install them, just copy the files into your
+
+```
+$PATH/.config/lite-xl/colors
+```
+directory.
+
+You can also copy them into
+```
+/wherever/lite-xl/is/installed/data/colors
+```
+if for some reason you need them available systemwide.

--- a/lite-xl/witch_hazel.lua
+++ b/lite-xl/witch_hazel.lua
@@ -1,0 +1,58 @@
+--[[
+Witch Hazel theme (https://github.com/theacodes/witchhazel)
+    A dark, feminine, color theme.
+for Lite-XL (https://lite-xl.com)
+--]]
+
+local style = require "core.style"
+local common = require "core.common"
+
+local sb_lilac    = { common.color "#3c374d" }
+local fg_white    = { common.color "#f8f8f2" }
+local kw_kiwi     = { common.color "#c2ffdf"}
+local c_grey      = { common.color "#b0bec5" }
+local err_fuchsia = { common.color "#f92672" }
+
+style.background  = { common.color "#433e56" }  -- Docview
+style.background2 = sb_lilac                    -- Treeview
+style.background3 = sb_lilac                    -- Command view
+style.text   = fg_white
+style.caret  = { common.color "#f8f8f0"}
+style.accent = { common.color "#e1e1e6" }
+-- style.dim - text color for nonactive tabs, tabs divider, prefix in log and
+-- search result, hotkeys for context menu and command view
+style.dim       = c_grey
+style.divider   = { common.color "#202024" } -- Line between nodes
+style.selection = { common.color "#8077a5" }
+style.line_number    = { common.color "#606860" }
+style.line_number2   = c_grey -- With cursor
+style.line_highlight = { common.color "#716799" }
+style.scrollbar       = sb_lilac
+style.scrollbar2      = { common.color "#4b4b52" } -- Hovered
+style.scrollbar_track = { common.color "#464258" }
+style.nagbar      = { common.color "#1e0010" }
+style.nagbar_text = err_fuchsia
+style.nagbar_dim  = { common.color "rgba(0, 0, 0, 0.45)" }
+style.drag_overlay     = { common.color "rgba(255,255,255,0.1)" }
+style.drag_overlay_tab = { common.color "#93DDFA" }
+style.good     = fg_white
+style.warn     = { common.color "#ff857f" }
+style.error    = err_fuchsia
+style.modified = { common.color "#1c7c9c" }
+
+style.syntax["normal"]   = fg_white
+style.syntax["symbol"]   = fg_white
+style.syntax["comment"]  = c_grey
+style.syntax["keyword"]  = kw_kiwi  -- local function end if case
+style.syntax["keyword2"] = kw_kiwi  -- self int float
+style.syntax["number"]   = { common.color "#c5a3ff" }
+style.syntax["literal"]  = { common.color "#ae81ff" }  -- true false nil
+style.syntax["string"]   = { common.color "#1bc5e0" }
+style.syntax["operator"] = { common.color "#ffb8d1" }  -- = + - / < >
+style.syntax["function"] = { common.color "#ceb1ff" }
+
+style.log["INFO"]  = { icon = "i", color = style.text }
+style.log["WARN"]  = { icon = "!", color = style.warn }
+style.log["ERROR"] = { icon = "!", color = style.error }
+
+return style

--- a/lite-xl/witch_hazel_hypercolor.lua
+++ b/lite-xl/witch_hazel_hypercolor.lua
@@ -1,0 +1,58 @@
+--[[
+Witch Hazel Hypercolor theme (https://github.com/theacodes/witchhazel)
+    A dark, feminine, color theme.
+for Lite-XL (https://lite-xl.com)
+--]]
+
+local style = require "core.style"
+local common = require "core.common"
+
+local bg_lilac    = { common.color "#282634" }
+local fg_white    = { common.color "#f8f8f2" }
+local kw_kiwi     = { common.color "#81ffbe"}
+local c_grey      = { common.color "#bfbfbf" }
+local err_fuchsia = { common.color "#f92672" }
+
+style.background  = bg_lilac -- Docview
+style.background2 = bg_lilac -- Treeview
+style.background3 = bg_lilac -- Command view
+style.text   = fg_white
+style.caret  = { common.color "#f8f8f0"}
+style.accent = kw_kiwi
+-- style.dim - text color for nonactive tabs, tabs divider, prefix in log and
+-- search result, hotkeys for context menu and command view
+style.dim       = c_grey
+style.divider   = { common.color "#202024" } -- Line between nodes
+style.selection = { common.color "#8077a5" }
+style.line_number    = { common.color "#606860" }
+style.line_number2   = c_grey                      -- With cursor
+style.line_highlight = { common.color "#131218" }
+style.scrollbar       = { common.color "#131218" }
+style.scrollbar2      = { common.color "#4b4b52" } -- Hovered
+style.scrollbar_track = { common.color "#464258" }
+style.nagbar      = { common.color "#1e0010" }
+style.nagbar_text = err_fuchsia
+style.nagbar_dim  = { common.color "rgba(0, 0, 0, 0.45)" }
+style.drag_overlay     = { common.color "rgba(255,255,255,0.1)" }
+style.drag_overlay_tab = { common.color "#93DDFA" }
+style.good     = fg_white
+style.warn     = { common.color "#ff857f" }
+style.error    = err_fuchsia
+style.modified = { common.color "#1c7c9c" }
+
+style.syntax["normal"]   = fg_white
+style.syntax["symbol"]   = fg_white
+style.syntax["comment"]  = c_grey
+style.syntax["keyword"]  = kw_kiwi  -- local function end if case
+style.syntax["keyword2"] = kw_kiwi  -- self int float
+style.syntax["number"]   = { common.color "#fff9a3" }
+style.syntax["literal"]  = { common.color "#ae81ff" }  -- true false nil
+style.syntax["string"]   = { common.color "#81eeff" }
+style.syntax["operator"] = { common.color "#ffb8d1" }  -- = + - / < >
+style.syntax["function"] = { common.color "#dcc8ff" }
+
+style.log["INFO"]  = { icon = "i", color = style.text }
+style.log["WARN"]  = { icon = "!", color = style.warn }
+style.log["ERROR"] = { icon = "!", color = style.error }
+
+return style


### PR DESCRIPTION
# What is this PR about?

[ ] closes issue number #

Adds versions of both themes for the [Lite XL](https://lite-xl.com) editor. Lite XL's themeability isn't nearly as granular as, for example, VS Code's, so some compromises have been made. Criticism welcome.

# Which editor(s) does this change concern?

- [ ] VS Code
- [ ] Sublime
- [ ] JetBrains
- [ ] Atom
- [ ] Pygments
- [x] Other: [Lite XL](https://lite-xl.com)

# The changes are for following theme variant(s):

- [x] Hypercolor
- [x] Classic

(If your change is only for one of these, please consider [submitting an issue](https://github.com/theacodes/witchhazel/issues/new) to document it to other contributors that these features are missing from the other variant. Having them listed in an issue makes it easier for people to contribute! 🎉)

# Screenshots

(Providing screenshots makes reviewing this PR quicker and easier.)

![Witch Hazel](https://github.com/theacodes/witchhazel/assets/16721230/30b76566-9593-4c7b-8e31-28baa33f859c)

![Witch Hazel Hypercolor](https://github.com/theacodes/witchhazel/assets/16721230/12a9a949-7078-4609-b9b2-79f89e3f9f25)
