### PR TITLE
Added versions of both themes for the Helix editor

### DIFF
--- a/helix/README.md
+++ b/helix/README.md
@@ -1,0 +1,10 @@
+Witch Hazel and Witch Hazel Hypercolor themes for the
+[Helix](https://helix-editor.com/) editor.
+
+To install them, just copy the files into either
+
+```
+~/.config/helix/themes/
+```
+
+or the `themes/` subdirectory of your installation's runtime directory.

--- a/helix/witchhazel.toml
+++ b/helix/witchhazel.toml
@@ -1,0 +1,74 @@
+
+"ui.background" = { bg = "purple" }
+"ui.text"       = "bone"
+
+"ui.cursor"        = { bg = "bone", fg = "murk" }
+"ui.cursor.normal" = { bg = "bone", fg = "murk" }
+"ui.cursor.insert" = { bg = "mint" }
+"ui.cursor.match"  = { bg = "smoke", fg = "salmon" }
+"ui.selection"     = { bg = "stone" }
+
+"ui.menu"  = { bg = "murk", fg = "bone" }
+"ui.menu.selected" = { bg = "nightshade" }
+"ui.help"  = { bg = "murk", fg = "cloud" }
+"ui.popup" = { bg = "murk", fg = "cloud" }
+"ui.highlight" = { bg = "purple", fg = "bone" }
+
+"ui.cursorline.primary"     = { bg = "nightshade" }
+"ui.cursorcolumn.primary"   = { bg = "nightshade" }
+"ui.cursorline.secondary"   = { bg = "cloud" }
+"ui.cursorcolumn.secondary" = { bg = "cloud" }
+
+"ui.statusline"        = { bg = "nightshade", fg = "bone" }
+"ui.statusline.normal" = { bg = "nightshade", fg = "bone" }
+"ui.statusline.insert" = { bg = "mint", fg = "murk" }
+"ui.statusline.select" = { modifiers = ["reversed"] }
+"ui.gutter"            = "stone"
+"ui.gutter.selected"   = { bg = "purple", fg = "smoke" }
+
+"ui.virtual" = "stone"
+"ui.virtual.ruler" = { bg = "nightshade" }
+
+"hint"    = "mint"
+"info"    = "daffodil"
+"warning" = "turquoise"
+"error"   = "salmon"
+"diagnostic" = { bg = "#purple" }
+"diagnostic.hint"    = { underline = { color = "mint", style = "curl" } }
+"diagnostic.info"    = { underline = { color = "daffodil", style = "curl" } }
+"diagnostic.warning" = { underline = { color = "turquoise", style = "curl" } }
+"diagnostic.error"   = { underline = { color = "salmon", style = "curl" } }
+
+"comment"      = "smoke"
+"string"       = "turquoise"
+"constant"     = "lilac"
+"keyword"      = "mint"
+"keyword.storage.type" = { modifiers = ["italic"] }
+"keyword.storage.modifier" = "salmon"
+"type"         = "bone"
+"type.builtin" = "mint"
+"function"     = "aster"
+"variable"     = "bone"
+"variable.parameter" = "salmon"
+"tag"          = "peony"
+"attribute"    = "daffodil"
+
+"diff.plus"  = "mint"
+"diff.minus" = "peony"
+"diff.delta" = "turquoise"
+
+[palette]
+purple     = "#433e56"
+nightshade = "#8077a8"
+murk       = "#3c374d"
+bone       = "#f8f8f2"
+cloud      = "#c6c4cc"
+smoke      = "#b0bec5"
+stone      = "#8a8a8a"
+turquoise  = "#1bc5e0"
+lilac      = "#c5a3ff"
+aster      = "#ceb1ff"
+mint       = "#c2ffdf"
+daffodil   = "#fff352"
+salmon     = "#ff857f"
+peony      = "#ffb8d1"

--- a/helix/witchhazel_hyper.toml
+++ b/helix/witchhazel_hyper.toml
@@ -1,0 +1,79 @@
+
+"ui.background" = { bg = "iris" }
+"ui.text"       = "bone"
+
+"ui.cursor"        = { bg = "bone", fg = "gloom" }
+"ui.cursor.normal" = { bg = "bone", fg = "gloom" }
+"ui.cursor.insert" = { bg = "fern" }
+"ui.cursor.match"  = { bg = "smoke", fg = "peony" }
+"ui.selection"     = { bg = "nightshade" }
+
+"ui.menu"          = { bg = "purple", fg = "cloud" }
+"ui.menu.selected" = { bg = "scum", fg = "gloom" }
+"ui.help"      = { bg = "purple", fg = "cloud" }
+"ui.popup"     = { bg = "purple", fg = "cloud" }
+"ui.window"    = { bg = "purple", fg = "cloud" }
+"ui.highlight" = { bg = "iris", fg = "bone" }
+
+"ui.cursorline.primary"     = { bg = "gloom" }
+"ui.cursorcolumn.primary"   = { bg = "gloom" }
+"ui.cursorline.secondary"   = { bg = "smoke" }
+"ui.cursorcolumn.secondary" = { bg = "smoke" }
+
+"ui.statusline"        = { bg = "thistle", fg = "bone" }
+"ui.statusline.normal" = { bg = "thistle", fg = "bone" }
+"ui.statusline.insert" = { bg = "mint", fg = "murk" }
+"ui.statusline.select" = { modifiers = ["reversed"] }
+"ui.gutter"            = "stone"
+"ui.gutter.selected"   = { bg = "gloom", fg = "cloud" }
+
+"ui.virtual" = "stone"
+"ui.virtual.ruler" = { bg = "gloom" }
+
+"hint"    = "fern"
+"info"    = "scotchbroom"
+"warning" = "carolina"
+"error"   = "peony"
+"diagnostic" = { bg = "iris" }
+"diagnostic.hint"    = { underline = { color = "fern", style = "curl" } }
+"diagnostic.info"    = { underline = { color = "scotchbroom", style = "curl" } }
+"diagnostic.warning" = { underline = { color = "carolina", style = "curl" } }
+"diagnostic.error"   = { underline = { color = "peony", style = "curl" } }
+
+"comment" = "smoke"
+"string"  = "carolina"
+"constant"         = { fg = "aster", modifiers = ["bold"] }
+"constant.numeric" = "scotchbroom"
+"keyword"                  = "fern"
+"keyword.storage.type"     = { fg = "fern", modifiers = ["italic"] }
+"keyword.storage.modifier" = { fg = "sound", modifiers = ["italic"] }
+"type.builtin" = "fern"
+"function" = "aster"
+"variable"           = "bone"
+"variable.parameter" = "peony"
+"tag"       = "peony"
+"attribute" = "scotchbroom"
+"punctuation.delimiter" = "fern"
+"operator" = "fern"
+
+"diff.plus"  = "mint"
+"diff.minus" = "peony"
+"diff.delta" = "turquoise"
+
+[palette]
+gloom       = "#131218"
+iris        = "#282634"
+purple      = "#433e56"
+nightshade  = "#8077a8"
+thistle     = "#8864cb"
+aster       = "#c5a3ff"
+stone       = "#8a8a8a"
+smoke       = "#bfbfbf"
+cloud       = "#c6c4cc"
+bone        = "#f8f8f0"
+scum        = "#64cb96"
+fern        = "#81ffbe"
+sound       = "#46becb"
+carolina    = "#81eeff"
+scotchbroom = "#fff9a3"
+peony       = "#ffb8d1"


### PR DESCRIPTION
# What is this PR about?

- [ ] closes issue number #

Adds versions of both themes for the [Helix](https://helix-editor.com/) editor.

Popups in the VSCode version of the Hypercolor theme (which I used as my reference) have a background color that is a brightish magenta; this didn't look nearly as good (at least to me) on the character grid in the terminal, so I took the liberty of making those backgrounds darker (visible in the screenshot below); I hope this is okay.

Criticism welcome.

# Which editor(s) does this change concern?

- [ ] VS Code
- [ ] Sublime
- [ ] JetBrains
- [ ] Atom
- [ ] Pygments
- [x] Other: [Helix](https://helix-editor.com/)

# The changes are for following theme variant(s):

- [x] Hypercolor
- [x] Classic

(If your change is only for one of these, please consider [submitting an issue](https://github.com/theacodes/witchhazel/issues/new) to document it to other contributors that these features are missing from the other variant. Having them listed in an issue makes it easier for people to contribute! 🎉)

# Screenshots

![wh](https://github.com/theacodes/witchhazel/assets/16721230/2cbe361a-4061-4f02-ab6d-086f85bc8b7a)

![whh](https://github.com/theacodes/witchhazel/assets/16721230/9b5e6fc6-1dc9-4f51-8f2a-96f42d0a80ee)
