### PR TITLE
adding kitty themes

### DIFF
--- a/kitty/witchhazel-hypercolor.conf
+++ b/kitty/witchhazel-hypercolor.conf
@@ -1,0 +1,80 @@
+# vim:ft=kitty
+
+## name:     Witch Hazel Hypercolor
+## author:   Anya Taylor
+## license:  MIT
+## upstream: 
+## blurb:    A dark & feminine color scheme.
+
+
+
+# The basic colors
+foreground              #F8F8F2
+background              #282634
+selection_foreground    #F8F8F0
+selection_background    #F4DBD6
+
+# Cursor colors
+cursor                  #F8F8F0
+cursor_text_color       #3B364E
+
+# URL underline color when hovering with mouse
+url_color               #FFB8D1
+
+# Kitty window border colors
+active_border_color     #DCC8FF
+inactive_border_color   #3B364E
+bell_border_color       #FFF9A3
+
+# OS Window titlebar colors
+wayland_titlebar_color system
+macos_titlebar_color system
+
+# Tab bar colors
+active_tab_foreground   #1e0010
+active_tab_background   #dcc8ff
+inactive_tab_foreground #1Bc5E0
+inactive_tab_background #1D1C27
+tab_bar_background      #282634
+
+# Colors for marks (marked text in the terminal)
+mark1_foreground #282634
+mark1_background #dcc8ff
+mark2_foreground #282634
+mark2_background #AE81FF
+mark3_foreground #282634
+mark3_background #1Bc5E0
+
+# The 16 terminal colors
+
+# black
+color0 #1e0010
+color8 #3B364E
+
+# red
+color1 #DC7070
+color9 #DC7070
+
+# green
+color2  #81FFBE
+color10 #81FFBE
+
+# yellow
+color3  #FFF9A3
+color11 #FFF9A3
+
+# blue
+color4  #1Bc5E0
+color12 #1Bc5E0
+
+# magenta
+color5  #FFB8D1
+color13 #FFB8D1
+
+# cyan
+color6  #81FFBE
+color14 #81FFBE
+
+# white
+color7  #DCC8FF
+color15 #BFBFBF

--- a/kitty/witchhazel.conf
+++ b/kitty/witchhazel.conf
@@ -1,0 +1,80 @@
+# vim:ft=kitty
+
+## name:     Witch Hazel
+## author:   Anya Taylor
+## license:  MIT
+## upstream: 
+## blurb:    A dark & feminine color scheme.
+
+
+
+# The basic colors
+foreground              #F8F8F2
+background              #433E56
+selection_foreground    #F8F8F2
+selection_background    #F4DBD6
+
+# Cursor colors
+cursor                  #F8F8F2
+cursor_text_color       #3B364E
+
+# URL underline color when hovering with mouse
+url_color               #FF857F
+
+# Kitty window border colors
+active_border_color     #CEB1FF
+inactive_border_color   #3B364E
+bell_border_color       #FFF352
+
+# OS Window titlebar colors
+wayland_titlebar_color system
+macos_titlebar_color system
+
+# Tab bar colors
+active_tab_foreground   #1e0010
+active_tab_background   #dcc8ff
+inactive_tab_foreground #1Bc5E0
+inactive_tab_background #1D1C27
+tab_bar_background      #433E56
+
+# Colors for marks (marked text in the terminal)
+mark1_foreground #433E56
+mark1_background #dcc8ff
+mark2_foreground #433E56
+mark2_background #C5A3FF
+mark3_foreground #433E56
+mark3_background #1Bc5E0
+
+# The 16 terminal colors
+
+# black
+color0 #1e0010
+color8 #3B364E
+
+# red
+color1 #F92672
+color9 #F92672
+
+# green
+color2  #C2FFDF
+color10 #C2FFDF
+
+# yellow
+color3  #FFF352
+color11 #FFF352
+
+# blue
+color4  #1Bc5E0
+color12 #1Bc5E0
+
+# magenta
+color5  #FF857F
+color13 #FF857F
+
+# cyan
+color6  #C2FFDF
+color14 #C2FFDF
+
+# white
+color7  #CEB1FF
+color15 #B0BEC5


### PR DESCRIPTION
# What is this PR about?

[x] closes issue number #43 

Adding Kitty themes for both looks. Pairs well with the nvim setup.

# Which editor(s) does this change concern?

- [x] Other: Kitty Terminal

# The changes are for following theme variant(s):

- [x] Hypercolor
- [x] Classic

(If your change is only for one of these, please consider [submitting an issue](https://github.com/theacodes/witchhazel/issues/new) to document it to other contributors that these features are missing from the other variant. Having them listed in an issue makes it easier for people to contribute! 🎉)

# Screenshots

Classic
![kitty-witchhazel](https://github.com/theacodes/witchhazel/assets/21206039/c11300e0-7ee3-43bc-99ca-2709902e5176)

Classic in Neovim
![kitty-witchhazel-nvim](https://github.com/theacodes/witchhazel/assets/21206039/f8e1f71e-ece9-4874-b7ba-666c5ef4ffaa)

Classic in LazyGit
![kitty-witchhazel-lazygit](https://github.com/theacodes/witchhazel/assets/21206039/5fb162af-c624-428f-9018-05b8b154c9f3)

Hypercolor
![kitty-witchhazel-hypercolor](https://github.com/theacodes/witchhazel/assets/21206039/86174423-91f5-431e-8717-5b3e0bf1b2e3)

Hypercolor in Neovim
![kitty-witchhazel-hypercolor-nvim](https://github.com/theacodes/witchhazel/assets/21206039/a41772d9-7324-4653-a4ba-d346e98601c8)

Hypercolor in LazyGit
![kitty-witchhazel-hypercolor-lazygit](https://github.com/theacodes/witchhazel/assets/21206039/a61b420e-da54-4522-bda6-c9870c021afc)
