### PR TITLE
Add theming for alacritty, adjust helix colors

### DIFF
--- a/alacritty/witchhazel.toml
+++ b/alacritty/witchhazel.toml
@@ -1,0 +1,49 @@
+# Witch Hazel Classic
+
+[colors.primary]
+background = '#433E56'
+foreground = '#F8F8F2'
+
+[colors.cursor]
+text   = '#3B364E'
+cursor = '#F8F8F2'
+
+[colors.search]
+matches       = { background = '#FFF352', foreground = '#433E56' }
+focused_match = { background = '#FFF352', foreground = '#433E56' }
+
+[colors.hints]
+start = { foreground = '#1E0010', background = '#DCC8FF' }
+end   = { foreground = '#1E0010', background = '#DCC8FF' }
+
+[colors.line_indicator]
+foreground = '#1E0010'
+background = '#DCC8FF'
+
+[colors.footer_bar]
+foreground = '#1E0010'
+background = '#DCC8FF'
+
+[colors.selection]
+text = 'CellForeground'
+background = '#716799'
+
+[colors.normal]
+black   = '#1e0010'
+red     = '#F92672'
+green   = '#C2FFDF'
+yellow  = '#FFF352'
+blue    = '#1BC5E0'
+magenta = '#FF857F'
+cyan    = '#C2FFDF'
+white   = '#CEB1FF'
+
+[colors.bright]
+black   = '#3B364E'
+red     = '#F92672'
+green   = '#C2FFDF'
+yellow  = '#FFF352'
+blue    = '#1BC5E0'
+magenta = '#FF857F'
+cyan    = '#C2FFDF'
+white   = '#B0BEC5'

--- a/alacritty/witchhazel_hyper.toml
+++ b/alacritty/witchhazel_hyper.toml
@@ -1,0 +1,49 @@
+# Witch Hazel Hypercolor
+
+[colors.primary]
+background = '#282634'
+foreground = '#F8F8F2'
+
+[colors.cursor]
+text   = '#3B364E'
+cursor = '#F8F8F0'
+
+[colors.search]
+matches       = { background = '#FFF9A3', foreground = '#282634' }
+focused_match = { background = '#FFF9A3', foreground = '#282634' }
+
+[colors.hints]
+start = { foreground = '#1E0010', background = '#DCC8FF' }
+end   = { foreground = '#1E0010', background = '#DCC8FF' }
+
+[colors.line_indicator]
+foreground = '#1E0010'
+background = '#DCC8FF'
+
+[colors.footer_bar]
+foreground = '#1E0010'
+background = '#DCC8FF'
+
+[colors.selection]
+text       = 'CellForeground'
+background = '#131218'
+
+[colors.normal]
+black   = '#1E0010'
+red     = '#DC7070'
+green   = '#81FFBE'
+yellow  = '#FFF9A3'
+blue    = '#1BC5E0'
+magenta = '#FFB8D1'
+cyan    = '#81FFBE'
+white   = '#DCC8FF'
+
+[colors.bright]
+black   = '#3B364E'
+red     = '#DC7070'
+green   = '#81FFBE'
+yellow  = '#FFF9A3'
+blue    = '#1BC5E0'
+magenta = '#FFB8D1'
+cyan    = '#81FFBE'
+white   = '#BFBFBF'

--- a/helix/witchhazel.toml
+++ b/helix/witchhazel.toml
@@ -5,8 +5,8 @@
 "ui.cursor"        = { bg = "bone", fg = "murk" }
 "ui.cursor.normal" = { bg = "bone", fg = "murk" }
 "ui.cursor.insert" = { bg = "mint" }
-"ui.cursor.match"  = { bg = "smoke", fg = "salmon" }
-"ui.selection"     = { bg = "stone" }
+"ui.cursor.match"  = "turquoise"
+"ui.selection"     = { bg = "amethyst" }
 
 "ui.menu"  = { bg = "murk", fg = "bone" }
 "ui.menu.selected" = { bg = "nightshade" }
@@ -72,3 +72,4 @@ mint       = "#c2ffdf"
 daffodil   = "#fff352"
 salmon     = "#ff857f"
 peony      = "#ffb8d1"
+amethyst   = "#716799"

--- a/helix/witchhazel_hyper.toml
+++ b/helix/witchhazel_hyper.toml
@@ -5,8 +5,8 @@
 "ui.cursor"        = { bg = "bone", fg = "gloom" }
 "ui.cursor.normal" = { bg = "bone", fg = "gloom" }
 "ui.cursor.insert" = { bg = "fern" }
-"ui.cursor.match"  = { bg = "smoke", fg = "peony" }
-"ui.selection"     = { bg = "nightshade" }
+"ui.cursor.match"  = "carolina"
+"ui.selection"     = { bg = "gloom" }
 
 "ui.menu"          = { bg = "purple", fg = "cloud" }
 "ui.menu.selected" = { bg = "scum", fg = "gloom" }


### PR DESCRIPTION
# What is this PR about?

* Added files (classic and hypercolor) for the alacritty terminal emulator
  * Based on the kitty themes from #44
* Adjusted theming for helix (both) to bring it more in line with the n/vim colors
  * Matching parentheses are no longer pink on grey (now blue)
  * Selection background color is no longer grey (now matches n/vim scheme)

# Which editor(s) does this change concern?

- [x] Other: Alacritty, Helix

# The changes are for following theme variant(s):

- [x] Hypercolor
- [x] Classic

# Screenshots
Alacritty classic:
![image](https://github.com/theacodes/witchhazel/assets/67898086/9499458f-88b1-422f-8af4-736575fbca30)

Alacritty hypercolor:
![image](https://github.com/theacodes/witchhazel/assets/67898086/b28bec6a-d95c-484f-bbf9-77d01fc69793)

# Additionally
While creating these themes I noticed that the kitty highlight text seems off? I didn't edit it because it was put there in #44 so I assume, as a non-kitty user, that it may have some meaning, but it might want to be changed in future if not.

Also, thank you for the wonderful theme, you did a great job creating and naming it (if I do say so myself~)