### PR TITLE
Bringing kitty highlight in line with theme

### DIFF
--- a/kitty/witchhazel-hypercolor.conf
+++ b/kitty/witchhazel-hypercolor.conf
@@ -12,7 +12,7 @@
 foreground              #F8F8F2
 background              #282634
 selection_foreground    #F8F8F0
-selection_background    #F4DBD6
+selection_background    #121218
 
 # Cursor colors
 cursor                  #F8F8F0

--- a/kitty/witchhazel.conf
+++ b/kitty/witchhazel.conf
@@ -12,7 +12,7 @@
 foreground              #F8F8F2
 background              #433E56
 selection_foreground    #F8F8F2
-selection_background    #F4DBD6
+selection_background    #726699
 
 # Cursor colors
 cursor                  #F8F8F2


### PR DESCRIPTION
# What is this PR about?

[x] addresses mention in  #45 

Corrected highlight colors as @0x-voidptr pointed out.

# Which editor(s) does this change concern?

- [x] Other: kitty

# The changes are for following theme variant(s):

- [x] Hypercolor
- [x] Classic

(If your change is only for one of these, please consider [submitting an issue](https://github.com/theacodes/witchhazel/issues/new) to document it to other contributors that these features are missing from the other variant. Having them listed in an issue makes it easier for people to contribute! 🎉)

# Screenshots

**Before:**
![kitty-witchhazel-before](https://github.com/theacodes/witchhazel/assets/21206039/7f1d9dfc-cb7f-4349-8b83-ce3b10db0679)

**After:**
![kitty-witchhazel-after](https://github.com/theacodes/witchhazel/assets/21206039/08c4fb8c-c9c0-470b-9e9c-b68d3b981ded)

**Before:**
![kitty-witchhazel-hypercolor-before](https://github.com/theacodes/witchhazel/assets/21206039/b1f2cf51-00c6-4057-a631-2c26183cb229)

**After:**
![kitty-witchhazel-hypercolor-after](https://github.com/theacodes/witchhazel/assets/21206039/5afd6ddd-e623-4735-a244-28c8818b6a06)