### PR TITLE
Adding Warp Terminal themes

### DIFF
--- a/warp/README.md
+++ b/warp/README.md
@@ -1,0 +1,13 @@
+## Usage
+
+1. `mkdir -p ~/.warp/themes` if the directory is not already created.
+2. `cd ~/.warp/themes` and `git clone https://github.com/theacodes/witchhazel witchhazel-full`.
+3. `mv -rf ~/.warp/themes/witchhazel-full/warp ~/.warp/themes/witchhazel`
+4. `rm -rf ~/.warp/themes/witchhazel-full`
+5. Open `Warp > Settings > Appearance > Themes`, scroll all the way down to see the new Witch Hazel themes.
+
+You might need to restart Warp for it to register the new themes as per [the documentation](https://docs.warp.dev/appearance/custom-themes#how-do-i-use-a-custom-theme-in-warp).
+
+> It may take several minutes for Warp to initially discover the new config directory. You can either wait or just restart the application. After that step, all future changes to `~/.warp/themes` directory will be reflected in Warp within seconds.
+
+**Credit:** Theacodes, `thanhsonng/rose-pine-warp`

--- a/warp/README.md
+++ b/warp/README.md
@@ -2,7 +2,7 @@
 
 1. `mkdir -p ~/.warp/themes` if the directory is not already created.
 2. `cd ~/.warp/themes` and `git clone https://github.com/theacodes/witchhazel witchhazel-full`.
-3. `mv -rf ~/.warp/themes/witchhazel-full/warp ~/.warp/themes/witchhazel`
+3. `mkdir witchhazel` and `mv ~/.warp/themes/witchhazel-full/warp/* ~/.warp/themes/witchhazel`
 4. `rm -rf ~/.warp/themes/witchhazel-full`
 5. Open `Warp > Settings > Appearance > Themes`, scroll all the way down to see the new Witch Hazel themes.
 

--- a/warp/witchhazel.yaml
+++ b/warp/witchhazel.yaml
@@ -1,0 +1,29 @@
+## name:     Witch Hazel
+## author:   Anya Taylor
+## license:  MIT
+## upstream: 
+## blurb:    A dark & feminine color scheme.
+
+accent: "#dcc8ff"
+background: "#433E56"
+foreground: "#F8F8F2"
+details: "darker"
+terminal_colors:
+  normal:
+    black: "#1e0010"
+    red: "#F92672"
+    green: "#C2FFDF"
+    yellow: "#FFF352"
+    blue: "#1Bc5E0"
+    magenta: "#FF857F"
+    cyan: "#C2FFDF"
+    white: "#CEB1FF"
+  bright:
+    black: "#3B364E"
+    red: "#F92672"
+    green: "#C2FFDF"
+    yellow: "#FFF352"
+    blue: "#1Bc5E0"
+    magenta: "#FF857F"
+    cyan: "#C2FFDF"
+    white: "#B0BEC5"

--- a/warp/witchhazel.yaml
+++ b/warp/witchhazel.yaml
@@ -4,7 +4,7 @@
 ## upstream: 
 ## blurb:    A dark & feminine color scheme.
 
-accent: "#dcc8ff"
+accent: "#726699"
 background: "#433E56"
 foreground: "#F8F8F2"
 details: "darker"

--- a/warp/witchhazel_hypercolor.yaml
+++ b/warp/witchhazel_hypercolor.yaml
@@ -4,7 +4,7 @@
 ## upstream: 
 ## blurb:    A dark & feminine color scheme.
 
-accent: "#dcc8ff"
+accent: "#8860CE"
 background: "#282634"
 foreground: "#F8F8F2"
 details: "darker"

--- a/warp/witchhazel_hypercolor.yaml
+++ b/warp/witchhazel_hypercolor.yaml
@@ -1,0 +1,29 @@
+## name:     Witch Hazel Hypercolor
+## author:   Anya Taylor
+## license:  MIT
+## upstream: 
+## blurb:    A dark & feminine color scheme.
+
+accent: "#dcc8ff"
+background: "#282634"
+foreground: "#F8F8F2"
+details: "darker"
+terminal_colors:
+  normal:
+    black: "#1e0010"
+    red: "#DC7070"
+    green: "#81FFBE"
+    yellow: "#FFF9A3"
+    blue: "#FFB8D1"
+    magenta: "#FFB8D1"
+    cyan: "#81FFBE"
+    white: "#DCC8FF"
+  bright:
+    black: "#3B364E"
+    red: "#DC7070"
+    green: "#81FFBE"
+    yellow: "#FFF9A3"
+    blue: "#1Bc5E0"
+    magenta: "#FFB8D1"
+    cyan: "#81FFBE"
+    white: "#BFBFBF"


### PR DESCRIPTION
# What is this PR about?

Adds another terminal theme yet-to-be mentioned in an issue. My co-workers are big fans so I needed themes for it. Warp's options are a bit bare bones. You can't specify multiple background colors for example.

# Which editor(s) does this change concern?

- [x] Other: Warp

# The changes are for following theme variant(s):

- [x] Hypercolor
- [x] Classic

(If your change is only for one of these, please consider [submitting an issue](https://github.com/theacodes/witchhazel/issues/new) to document it to other contributors that these features are missing from the other variant. Having them listed in an issue makes it easier for people to contribute! 🎉)

# Screenshots

![warp-witchhazel-hypercolor](https://github.com/theacodes/witchhazel/assets/21206039/8cc43f64-cc1a-4597-9deb-691f383aa90b)
![warp-witchhazel](https://github.com/theacodes/witchhazel/assets/21206039/d0bb867c-cb6d-42d9-8dc9-2c3f6c5dc2b0)
