### PR TITLE
pywal / pywal16 and mintty versions

### DIFF
--- a/mintty/witchhazel
+++ b/mintty/witchhazel
@@ -1,0 +1,160 @@
+# witchhazel theme for use with mintty
+#
+#   "scheme-name": "witchhazel",
+#   "scheme-author": "theacodes and 0x-voidptr",
+#   "scheme-slug": "witchhazel",
+#
+#   scheme-comment:  https://github.com/theacodes/witchhazel
+#   scheme-comment1: https://witchhazel.thea.codes/
+#   scheme-comment2: TODO add color comments with names, see https://github.com/theacodes/witchhazel/blob/master/witchhazel.nvim/lua/witchhazel/palette.lua
+#   scheme-comment3: 
+#   scheme-comment4: 
+#   scheme-comment5: 
+#   scheme-comment6: 
+#   scheme-comment7: 
+#   scheme-comment8: 
+#   scheme-comment9: 
+#
+#   - https://mintty.github.io/
+#   - https://github.com/mintty/mintty
+#   - https://mintty.github.io/mintty.1.html
+#
+# NOTE tstk has no concept of different colors for foreground and
+# background versions of a color name as described in
+# https://mintty.github.io/mintty.1.html#CONFIGURATION section, "ANSI colours"
+# > The ANSI colours can have different values for foreground and background use.
+# > These need to be separated by a semicolon, for example 127,127,127;85,85,85
+# > for different shades of grey. If only one value is specified,
+# > it is used for both foreground and background.
+
+# Colour2-comment: 
+#    Colour2-note: 
+#         Colour2: #433E56
+BackgroundColour = 67,62,86
+
+# Colour0-comment: 
+#    Colour0-note: 
+#         Colour0: #F8F8F2
+ForegroundColour = 248,248,242
+
+# Colour5-comment: 
+#    Colour5-note: 
+#         Colour5: #F8F8F2
+CursorColour = 248,248,242
+
+
+# ANSI Black
+# 30m / 40m
+#  Colour6-comment: 
+#     Colour6-note: 
+#          Colour6: #1e0010
+Black = 30,0,16
+
+# ANSI Black Bright
+# 1;30m
+#  Colour7-comment: 
+#     Colour7-note: 
+#          Colour7: #3B364E
+BoldBlack = 59,54,78
+
+# ANSI Red
+# 31m / 41m
+#  Colour8-comment: 
+#     Colour8-note: 
+#          Colour8: #F92672
+Red = 249,38,114
+
+# ANSI Red Bright
+# 1;31m
+#  Colour9-comment: 
+#     Colour9-note: 
+#          Colour9: #F92672
+BoldRed = 249,38,114
+
+# ANSI Green
+# 32m / 42m
+# Colour10-comment: 
+#    Colour10-note: 
+#         Colour10: #C2FFDF
+Green = 194,255,223
+
+# ANSI Green Bright
+# 1;32m
+# Colour11-comment: 
+#    Colour11-note: 
+#         Colour11: #C2FFDF
+BoldGreen = 194,255,223
+
+# ANSI Yellow
+# 33m / 43m
+# Colour12-comment: 
+#    Colour12-note: 
+#         Colour12: #FFF352
+Yellow = 255,243,82
+
+# ANSI Yellow Bright
+# 1;33m
+# Colour13-comment: 
+#    Colour13-note: 
+#         Colour13: #FFF352
+BoldYellow = 255,243,82
+
+# ANSI Blue
+# 34m / 44m
+# Colour14-comment: 
+#    Colour14-note: 
+#         Colour14: #1BC5E0
+Blue = 27,197,224
+
+# ANSI Blue Bright
+# 1;34m
+# Colour15-comment: 
+#    Colour15-note: 
+#         Colour15: #1BC5E0
+BoldBlue = 27,197,224
+
+# ANSI Magenta
+# 35m / 45m
+# Colour16-comment: 
+#    Colour16-note: 
+#         Colour16: #FF857F
+Magenta = 255,133,127
+
+# ANSI Magenta Bright
+# 1;35m
+# Colour17-comment: 
+#    Colour17-note: 
+#         Colour17: #FF857F
+BoldMagenta = 255,133,127
+
+# ANSI Cyan
+# 36m / 46m
+# Colour18-comment: 
+#    Colour18-note: 
+#         Colour18: #C2FFDF
+Cyan = 194,255,223
+
+# ANSI Cyan Bright
+# 1;36m
+# Colour19-comment: 
+#    Colour19-note: 
+#         Colour19: #C2FFDF
+BoldCyan = 194,255,223
+
+# ANSI White
+# 37m / 47m
+# Colour20-comment: 
+#    Colour20-note: 
+#         Colour20: #CEB1FF
+White = 206,177,255
+
+# ANSI White Bright
+# 1;37m
+# Colour21-comment: 
+#    Colour21-note: 
+#         Colour21: #B0BEC5
+BoldWhite = 176,190,197
+
+# {{! Theme rendered with https://github.com/clach04/terminal_style_toolkit }}
+# {{! py -3 json2putty_reg.py putty_themes\raw_themes\Nord_flipped_blue.json mintty_theme.mustache %APPDATA%\mintty\themes\Nord_flipped_blue }}
+# {{! "C:\Program Files\Git\usr\bin\mintty.exe" --title "mintty show colors" --hold  always --size 90,65 py -3 pyshow_colors2.py }}

--- a/mintty/witchhazel_hyper
+++ b/mintty/witchhazel_hyper
@@ -1,0 +1,160 @@
+# witchhazel_hyper theme for use with mintty
+#
+#   "scheme-name": "witchhazel_hyper",
+#   "scheme-author": "theacodes and 0x-voidptr",
+#   "scheme-slug": "witchhazel_hyper",
+#
+#   scheme-comment:  https://github.com/theacodes/witchhazel
+#   scheme-comment1: https://witchhazel.thea.codes/
+#   scheme-comment2: TODO add color comments with names, see https://github.com/theacodes/witchhazel/blob/master/witchhazel.nvim/lua/witchhazel/palette.lua
+#   scheme-comment3: 
+#   scheme-comment4: 
+#   scheme-comment5: 
+#   scheme-comment6: 
+#   scheme-comment7: 
+#   scheme-comment8: 
+#   scheme-comment9: 
+#
+#   - https://mintty.github.io/
+#   - https://github.com/mintty/mintty
+#   - https://mintty.github.io/mintty.1.html
+#
+# NOTE tstk has no concept of different colors for foreground and
+# background versions of a color name as described in
+# https://mintty.github.io/mintty.1.html#CONFIGURATION section, "ANSI colours"
+# > The ANSI colours can have different values for foreground and background use.
+# > These need to be separated by a semicolon, for example 127,127,127;85,85,85
+# > for different shades of grey. If only one value is specified,
+# > it is used for both foreground and background.
+
+# Colour2-comment: 
+#    Colour2-note: 
+#         Colour2: #282634
+BackgroundColour = 40,38,52
+
+# Colour0-comment: 
+#    Colour0-note: 
+#         Colour0: #F8F8F2
+ForegroundColour = 248,248,242
+
+# Colour5-comment: 
+#    Colour5-note: 
+#         Colour5: #F8F8F0
+CursorColour = 248,248,240
+
+
+# ANSI Black
+# 30m / 40m
+#  Colour6-comment: 
+#     Colour6-note: 
+#          Colour6: #1E0010
+Black = 30,0,16
+
+# ANSI Black Bright
+# 1;30m
+#  Colour7-comment: 
+#     Colour7-note: 
+#          Colour7: #3B364E
+BoldBlack = 59,54,78
+
+# ANSI Red
+# 31m / 41m
+#  Colour8-comment: 
+#     Colour8-note: 
+#          Colour8: #DC7070
+Red = 220,112,112
+
+# ANSI Red Bright
+# 1;31m
+#  Colour9-comment: 
+#     Colour9-note: 
+#          Colour9: #DC7070
+BoldRed = 220,112,112
+
+# ANSI Green
+# 32m / 42m
+# Colour10-comment: 
+#    Colour10-note: 
+#         Colour10: #81FFBE
+Green = 129,255,190
+
+# ANSI Green Bright
+# 1;32m
+# Colour11-comment: 
+#    Colour11-note: 
+#         Colour11: #81FFBE
+BoldGreen = 129,255,190
+
+# ANSI Yellow
+# 33m / 43m
+# Colour12-comment: 
+#    Colour12-note: 
+#         Colour12: #FFF9A3
+Yellow = 255,249,163
+
+# ANSI Yellow Bright
+# 1;33m
+# Colour13-comment: 
+#    Colour13-note: 
+#         Colour13: #FFF9A3
+BoldYellow = 255,249,163
+
+# ANSI Blue
+# 34m / 44m
+# Colour14-comment: 
+#    Colour14-note: 
+#         Colour14: #1BC5E0
+Blue = 27,197,224
+
+# ANSI Blue Bright
+# 1;34m
+# Colour15-comment: 
+#    Colour15-note: 
+#         Colour15: #1BC5E0
+BoldBlue = 27,197,224
+
+# ANSI Magenta
+# 35m / 45m
+# Colour16-comment: 
+#    Colour16-note: 
+#         Colour16: #FFB8D1
+Magenta = 255,184,209
+
+# ANSI Magenta Bright
+# 1;35m
+# Colour17-comment: 
+#    Colour17-note: 
+#         Colour17: #FFB8D1
+BoldMagenta = 255,184,209
+
+# ANSI Cyan
+# 36m / 46m
+# Colour18-comment: 
+#    Colour18-note: 
+#         Colour18: #81FFBE
+Cyan = 129,255,190
+
+# ANSI Cyan Bright
+# 1;36m
+# Colour19-comment: 
+#    Colour19-note: 
+#         Colour19: #81FFBE
+BoldCyan = 129,255,190
+
+# ANSI White
+# 37m / 47m
+# Colour20-comment: 
+#    Colour20-note: 
+#         Colour20: #DCC8FF
+White = 220,200,255
+
+# ANSI White Bright
+# 1;37m
+# Colour21-comment: 
+#    Colour21-note: 
+#         Colour21: #BFBFBF
+BoldWhite = 191,191,191
+
+# {{! Theme rendered with https://github.com/clach04/terminal_style_toolkit }}
+# {{! py -3 json2putty_reg.py putty_themes\raw_themes\Nord_flipped_blue.json mintty_theme.mustache %APPDATA%\mintty\themes\Nord_flipped_blue }}
+# {{! "C:\Program Files\Git\usr\bin\mintty.exe" --title "mintty show colors" --hold  always --size 90,65 py -3 pyshow_colors2.py }}

--- a/pywal/witchhazel.json
+++ b/pywal/witchhazel.json
@@ -1,0 +1,31 @@
+{
+  "special": {
+    "foreground": "F8F8F2",
+    "background": "433E56",
+    "cursor": "F8F8F2"
+  },
+  "colors": {
+    "color0": "1e0010",
+    "color1": "F92672",
+    "color2": "C2FFDF",
+    "color3": "FFF352",
+    "color4": "1BC5E0",
+    "color5": "FF857F",
+    "color6": "C2FFDF",
+    "color7": "CEB1FF",
+    "color8": "3B364E",
+    "color9": "F92672",
+    "color10": "C2FFDF",
+    "color11": "FFF352",
+    "color12": "1BC5E0",
+    "color13": "FF857F",
+    "color14": "C2FFDF",
+    "color15": "B0BEC5",
+
+
+    "color16": "3B364E",
+    "color17": "F8F8F2"
+  },
+  "TST_COMMENT1": "color16 and color17 **could** be fg_bold and cursor_text?",
+  "TST_COMMENT2": "template to generate pywal16.json file from https://github.com/clach04/terminal_style_toolkit/"
+}

--- a/pywal/witchhazel_hyper.json
+++ b/pywal/witchhazel_hyper.json
@@ -1,0 +1,31 @@
+{
+  "special": {
+    "foreground": "F8F8F2",
+    "background": "282634",
+    "cursor": "F8F8F0"
+  },
+  "colors": {
+    "color0": "1E0010",
+    "color1": "DC7070",
+    "color2": "81FFBE",
+    "color3": "FFF9A3",
+    "color4": "1BC5E0",
+    "color5": "FFB8D1",
+    "color6": "81FFBE",
+    "color7": "DCC8FF",
+    "color8": "3B364E",
+    "color9": "DC7070",
+    "color10": "81FFBE",
+    "color11": "FFF9A3",
+    "color12": "1BC5E0",
+    "color13": "FFB8D1",
+    "color14": "81FFBE",
+    "color15": "BFBFBF",
+
+
+    "color16": "3B364E",
+    "color17": "F8F8F0"
+  },
+  "TST_COMMENT1": "color16 and color17 **could** be fg_bold and cursor_text?",
+  "TST_COMMENT2": "template to generate pywal16.json file from https://github.com/clach04/terminal_style_toolkit/"
+}


### PR DESCRIPTION
Based on alacritty / kitty.

# What is this PR about?

Implements themes for pywal, for generating themes for all sorts of tools. As well as mintty the Terminal Emulator.

(Describe what are the changes and why you have made them.)

# Which editor(s) does this change concern?

- [ ] VS Code
- [ ] Sublime
- [ ] JetBrains
- [ ] Atom
- [ ] Pygments
- [x] Other: Not an editor, this is for terminal mintty and pywal the theme generator
- [ ] 
# The changes are for following theme variant(s):

- [x] Hypercolor
- [x] Classic



# Screenshots

![witchhazel](https://github.com/user-attachments/assets/4035c3c5-6927-492e-9f8a-de872f11013a)

![witchhazel_hyper](https://github.com/user-attachments/assets/1cb77bef-2e1a-4b1b-a94e-4db1ba501a31)
